### PR TITLE
fixing import from toolbelt to local Tester file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+- [e2e index] Now test-plugin import functions from local Tester.ts file, not anymore from vtex package 
 ## [0.0.3] - 2020-07-07
 
 ## [0.0.2] - 2020-07-07

--- a/src/modules/apps/e2e/index.ts
+++ b/src/modules/apps/e2e/index.ts
@@ -2,8 +2,6 @@ import chalk from 'chalk'
 
 import {
   createAppsClient,
-  TestRequest,
-  AppReport,
   ManifestEditor,
   SessionManager,
   parseLocator,
@@ -14,7 +12,7 @@ import {
 
 import { parseReport, AppTest, passedApp } from './specsState'
 
-import { Tester } from '../../../clients/Tester'
+import { Tester, AppReport, TestRequest } from '../../../clients/Tester'
 
 const POLL_INTERVAL = 2000
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Now `test-plugin` import functions from local `Tester.ts` file, not anymore from `vtex` package 

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [x] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`